### PR TITLE
Upgraded to Ember 1.11.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ember-list-view-bug",
   "dependencies": {
     "jquery": "^1.11.1",
-    "ember": "1.11.0",
+    "ember": "1.11.1",
     "ember-data": "1.0.0-beta.16.1",
     "ember-resolver": "~0.1.15",
     "loader.js": "ember-cli/loader.js#3.2.0",


### PR DESCRIPTION
Ember 1.10.0 is incompatible with Ember List View due to a regression that was introduced to the Collection View. https://github.com/emberjs/ember.js/pull/10795